### PR TITLE
Switch components to ID

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -209,18 +209,33 @@ app.use(
   ),
 );
 
+const getNormalizedUrl = (ctx, isChapter) => {
+  const { url, id } = ctx.request.query;
+
+  if (url) {
+    return url;
+  }
+
+  ctx.assert(id, 400, `Could not find 'url' or 'id' params`);
+
+  const components = id.split(':');
+
+  ctx.assert(components.length > 1 && components.length < 4, 400, `Invalid ID format (${id})`);
+
+  const isCorrectFormat = isChapter
+    ? components.length === 3
+    : components.length === 2;
+
+  ctx.assert(isCorrectFormat, 400, `Invalid ${isChapter ? 'chapter' : 'series'} ID (${id})`);
+
+  return poketo.constructUrl(...components);
+};
+
 app.use(
   route.get(
     '/series',
     async (ctx) => {
-      const { url, siteId, seriesSlug } = ctx.request.query;
-
-      const hasUrl = Boolean(url);
-
-      let normalizedUrl = hasUrl
-        ? url
-        : poketo.constructUrl(siteId, seriesSlug);
-
+      const normalizedUrl = getNormalizedUrl(ctx, false);
       const start = Date.now();
       ctx.body = await poketo.getSeries(normalizedUrl);
       const diff = Date.now() - start;
@@ -237,14 +252,7 @@ app.use(
   route.get(
     '/chapter',
     async (ctx) => {
-      const { url, siteId, seriesSlug, chapterSlug } = ctx.request.query;
-
-      const hasUrl = Boolean(url);
-
-      let normalizedUrl = hasUrl
-        ? url
-        : poketo.constructUrl(siteId, seriesSlug, chapterSlug);
-
+      const normalizedUrl = getNormalizedUrl(ctx, true);
       const start = Date.now();
       ctx.body = await poketo.getChapter(normalizedUrl);
       const diff = Date.now() - start;


### PR DESCRIPTION
This PR moves the API from using individual components (eg. `siteId`, `seriesSlug`, `chapterSlug`) to the single ID format (eg. `meraki-scans:senryu-girl:5`). It's both easier to read and to write code for.